### PR TITLE
Replace nngpp with nngxx

### DIFF
--- a/docs/rst/library/core/events.rst
+++ b/docs/rst/library/core/events.rst
@@ -26,7 +26,7 @@ Events
 .. doxygenstruct:: pars::ev::uuid
 .. doxygenstruct:: pars::ev::base_klass
 .. doxygenstruct:: pars::ev::klass
-.. doxygenstruct:: pars::ev::klass< nng::msg >
+.. doxygenstruct:: pars::ev::klass< nngxx::msg >
 .. doxygenstruct:: pars::ev::klass< std::shared_ptr< event_t > >
 
 .. doxygenstruct:: pars::ev::metadata

--- a/docs/rst/library/core/kinds.rst
+++ b/docs/rst/library/core/kinds.rst
@@ -6,7 +6,7 @@ Kinds
 .. doxygenstruct:: pars::ev::sent
 
 .. doxygenstruct:: pars::ev::received
-.. doxygenstruct:: pars::ev::received< nng::msg >
+.. doxygenstruct:: pars::ev::received< nngxx::msg >
 
 .. doxygenstruct:: pars::ev::common_kind
 

--- a/docs/rst/library/net/core.rst
+++ b/docs/rst/library/net/core.rst
@@ -17,7 +17,7 @@ Core
 
 .. doxygenclass:: pars::net::tool_view
 
-.. doxygentypedef:: nng::cb_f
+.. doxygentypedef:: nngxx::cb_f
 
 .. doxygenenum:: pars::net::cmode
 

--- a/example/server_backend.cpp
+++ b/example/server_backend.cpp
@@ -162,7 +162,7 @@ private:
     }
     else
     {
-      md.pipe().close();
+      md.pipe().close().or_abort();
 
       pars::info(SL, "{}: Fired {}, Pipe Rejected! [# resources: {} >= {}]", md,
                  ev, resources_count, max_allowed);
@@ -314,7 +314,7 @@ private:
 
     resources.delete_resource(p.id());
 
-    p.close();
+    p.close().or_abort();
 
     auto& ctx = comp().rep().ctxs().of(md.tool());
 

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -1,11 +1,14 @@
-# set (THREADS_PREFER_PTHREAD_FLAG ON)
 find_package (Threads REQUIRED)
-find_package (fmt CONFIG REQUIRED)
 find_package (nng CONFIG REQUIRED)
+find_package (fmt CONFIG REQUIRED)
 find_package (spdlog CONFIG REQUIRED)
 
 # sorted please
 set (PARS_HEADERS
+    "include/clev/err.h"
+    "include/clev/iface.h"
+    "include/clev/own.h"
+    "include/clev/value.h"
     "include/pars/app/resources.h"
     "include/pars/app/setup.h"
     "include/pars/app/single.h"
@@ -57,6 +60,29 @@ set (PARS_HEADERS
     "include/pars/init.h"
     "include/pars/log.h"
     "include/pars/pars.h"
+    "include/nngxx/iface/aio.h"
+    "include/nngxx/iface/ctx.h"
+    "include/nngxx/iface/dialer.h"
+    "include/nngxx/iface/listener.h"
+    "include/nngxx/iface/msg.h"
+    "include/nngxx/iface/pipe.h"
+    "include/nngxx/iface/socket.h"
+    "include/nngxx/iface/value.h"
+    "include/nngxx/aio.h"
+    "include/nngxx/concept.h"
+    "include/nngxx/ctx.h"
+    "include/nngxx/dialer.h"
+    "include/nngxx/err.h"
+    "include/nngxx/listener.h"
+    "include/nngxx/msg.h"
+    "include/nngxx/msg_body.h"
+    "include/nngxx/msg_header.h"
+    "include/nngxx/opt.h"
+    "include/nngxx/opt_getter.h"
+    "include/nngxx/opt_setter.h"
+    "include/nngxx/pipe.h"
+    "include/nngxx/socket.h"
+    "include/nngxx/socket_decl.h"
 )
 
 add_library (pars INTERFACE ${PARS_HEADERS})
@@ -72,8 +98,8 @@ target_sources (
 target_link_libraries (
     pars
     INTERFACE
-    nng::nng
     fmt::fmt
+    nng::nng
     spdlog::spdlog
 )
 
@@ -104,37 +130,37 @@ install (
     LIBRARY FILE_SET HEADERS
 )
 
-install(
+install (
     FILES ${CMAKE_BINARY_DIR}/lib/generated/config.h
     DESTINATION include/pars
 )
 
-export(
+export (
     TARGETS pars
     NAMESPACE pars::
     FILE "${CMAKE_CURRENT_BINARY_DIR}/${pars_config_targets_file}"
 )
 
-install(
+install (
     EXPORT pars
     DESTINATION ${pars_export_dest_dir}
     NAMESPACE pars::
     FILE ${pars_config_targets_file}
 )
 
-include(CMakePackageConfigHelpers)
-configure_package_config_file(
+include (CMakePackageConfigHelpers)
+configure_package_config_file (
     "${pars_project_config_in}"
     "${pars_project_config_out}"
     INSTALL_DESTINATION ${pars_export_dest_dir}
 )
 
-write_basic_package_version_file(
+write_basic_package_version_file (
     "${pars_version_config_file}"
     COMPATIBILITY SameMajorVersion
 )
 
-install(
+install (
     FILES "${pars_project_config_out}" "${pars_version_config_file}"
     DESTINATION "${pars_export_dest_dir}"
 )

--- a/lib/include/clev/err.h
+++ b/lib/include/clev/err.h
@@ -1,0 +1,244 @@
+/*
+Copyright (c) 2025 Giuseppe Roberti.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+this list of conditions and the following disclaimer in the documentation and/or
+other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors
+may be used to endorse or promote products derived from this software without
+specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+#pragma once
+
+#include <fmt/format.h>
+#include <nng/nng.h>
+
+#include <expected>
+#include <functional>
+
+namespace clev
+{
+
+struct exception : std::runtime_error
+{
+  explicit exception(std::error_code code) noexcept
+    : std::runtime_error(code.message())
+  {
+  }
+};
+
+#if __cpp_exceptions < 199711
+constexpr static bool clev_exception_disabled_v = true;
+#else
+constexpr static bool clev_exception_disabled_v = false;
+#endif
+inline static void
+abort_now(const std::error_code err) noexcept(clev_exception_disabled_v)
+{
+  if constexpr (clev_exception_disabled_v)
+    std::quick_exit(err.value());
+  else
+    throw exception{err};
+}
+
+inline static void exit_now(const std::error_code err) noexcept
+{
+  std::quick_exit(err.value());
+}
+
+struct unexpected : std::unexpected<std::error_code>
+{
+private:
+  using parent = std::unexpected<std::error_code>;
+
+public:
+  using parent::parent;
+};
+
+template<typename value_t>
+struct expected;
+
+template<typename>
+struct is_expected_specialization : std::false_type
+{
+};
+
+template<template<typename> typename expected_t, typename value_t>
+struct is_expected_specialization<expected_t<value_t>>
+  : std::is_same<expected_t<value_t>, expected<value_t>>
+{
+};
+
+template<typename expected_t>
+inline constexpr bool is_expected_specialization_v =
+  is_expected_specialization<expected_t>::value;
+
+template<>
+struct expected<void> : public std::expected<void, std::error_code>
+{
+private:
+  using parent = std::expected<void, std::error_code>;
+
+public:
+  using parent::parent;
+
+  constexpr void or_abort() noexcept(clev_exception_disabled_v)
+  {
+    if (!*this)
+      abort_now(expected::error());
+  }
+
+  constexpr void or_exit() noexcept
+  {
+    if (!*this)
+      exit_now(expected::error());
+  }
+
+  template<typename to_value_t>
+  [[nodiscard]] auto transform_to(to_value_t&& v) && noexcept
+  {
+    if (*this)
+      return expected<to_value_t>(std::move(v));
+    else
+      return expected<to_value_t>(unexpected(std::move(parent::error())));
+  }
+};
+
+template<typename value_t>
+struct expected : public std::expected<value_t, std::error_code>
+{
+private:
+  using parent = std::expected<value_t, std::error_code>;
+
+  using error_type = parent::error_type;
+
+public:
+  using parent::parent;
+
+  [[nodiscard]] expected::value_type&
+  value_or_abort() & noexcept(clev_exception_disabled_v)
+  {
+    if (!*this)
+      abort_now(expected::error());
+
+    return expected::value();
+  }
+
+  [[nodiscard]] expected::value_type&&
+  value_or_abort() && noexcept(clev_exception_disabled_v)
+  {
+    if (!*this)
+      abort_now(expected::error());
+
+    return std::move(expected::value());
+  }
+
+  [[nodiscard]] constexpr const expected::value_type&
+  value_or_abort() const& noexcept(clev_exception_disabled_v)
+  {
+    if (!*this)
+      abort_now(expected::error());
+
+    return expected::value();
+  }
+
+  [[nodiscard]] constexpr const expected::value_type&&
+  value_or_abort() const&& noexcept(clev_exception_disabled_v)
+  {
+    if (!*this)
+      abort_now(expected::error());
+
+    return std::move(expected::value());
+  }
+
+  [[nodiscard]] expected<std::reference_wrapper<value_t>>
+  and_assign_to(value_t& dest) && noexcept
+  {
+    if (*this)
+    {
+      dest = std::move(expected::value());
+
+      return std::ref(dest);
+    }
+
+    return unexpected{std::move(expected::error())};
+  }
+
+  template<typename fn_t>
+    requires std::is_constructible_v<error_type, error_type&>
+  [[nodiscard]] auto and_then(fn_t&& f) && noexcept
+  {
+    using exp_t = std::remove_cvref_t<
+      std::invoke_result_t<fn_t, decltype(std::move(expected::value()))>>;
+
+    static_assert(is_expected_specialization_v<exp_t>,
+                  "expected<value_t>::and_then(fn_t) must specialize");
+
+    static_assert(std::is_same_v<typename exp_t::error_type, error_type>,
+                  "expected<value_t>::and_then(fn_t) requires same error");
+
+    if (*this)
+      return std::invoke(std::forward<fn_t>(f), std::move(expected::value()));
+    else
+      return exp_t{std::unexpect, std::move(expected::error())};
+  }
+
+  template<typename to_value_t>
+  [[nodiscard]] auto transform_to() && noexcept
+  {
+    if (*this)
+      return expected<to_value_t>(std::move(parent::value()));
+    else
+      return expected<to_value_t>(unexpected(std::move(parent::error())));
+  }
+
+  template<typename to_value_t>
+  [[nodiscard]] auto transform_to(to_value_t&& v) && noexcept
+  {
+    if (*this)
+      return expected<value_t>(std::move(v));
+    else
+      return std::move(*this);
+  }
+
+  [[nodiscard]] auto discard_value() && noexcept
+  {
+    if (*this)
+      return expected<void>{};
+    else
+      return expected<void>{std::unexpect, expected::error()};
+  }
+};
+
+template<typename value_t>
+expected(value_t&&) -> expected<value_t>;
+
+template<typename enum_t>
+inline clev::expected<void> make_expected(const int e) noexcept
+{
+  if (e != 0)
+    return clev::unexpected(static_cast<enum_t>(e));
+
+  return {};
+}
+
+} // namespace clev

--- a/lib/include/clev/iface.h
+++ b/lib/include/clev/iface.h
@@ -29,61 +29,10 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 #pragma once
 
-#include "pars/init.h"
-
-#include "nngxx/ctx.h"
-#include "nngxx/socket.h"
-
-#include <fmt/format.h>
-
-#include <typeinfo>
-#include <variant>
-
-namespace pars::net
+namespace clev
 {
 
-/**
- * @brief Represents an nng_socket or nng_ctx view
- */
-class tool_view
-{
-public:
-  /// Construct a tool_view from an nng_ctx view
-  explicit tool_view(nngxx::ctx_view c)
-    : tool_m{c}
-  {
-  }
+template<typename wrap_t>
+struct iface;
 
-  /// Construct a tool_view from an nng_socket view
-  explicit tool_view(nngxx::socket_view s)
-    : tool_m{s}
-  {
-  }
-
-  /// Get the std::type_info of the underlying variant
-  const std::type_info& type() const
-  {
-    return std::visit([](auto& t) { return std::ref(typeid(t)); }, tool_m);
-  }
-
-  /// Get a string that represents the type of the underlying variant
-  const char* who() const { return tool_m.index() == 0 ? "Context" : "Socket"; }
-
-  /// The id of the underlying variant
-  int id() const
-  {
-    return std::visit([](const auto& t) { return t.id(); }, tool_m);
-  }
-
-  /// Formatter for debugging purpose
-  auto format_to(fmt::format_context& ctx) const -> decltype(ctx.out())
-  {
-    return fmt::format_to(ctx.out(), "{} #{}", who(), id());
-  }
-
-private:
-  /// The underlying variant that represents either an nng_socket or nng_ctx
-  const std::variant<nngxx::ctx_view, nngxx::socket_view> tool_m;
-};
-
-} // namespace pars::net
+} // namespace clev

--- a/lib/include/clev/own.h
+++ b/lib/include/clev/own.h
@@ -1,0 +1,115 @@
+/*
+Copyright (c) 2025 Giuseppe Roberti.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+this list of conditions and the following disclaimer in the documentation and/or
+other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors
+may be used to endorse or promote products derived from this software without
+specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+#pragma once
+
+#include "clev/err.h"
+#include "clev/iface.h"
+
+namespace clev
+{
+
+template<typename wrap_t>
+struct own : iface<wrap_t>
+{
+  using parent = iface<wrap_t>;
+
+  using parent::parent;
+
+  own(const own& rhs) noexcept
+    requires requires(wrap_t* d, const wrap_t s) {
+    { iface<wrap_t>::copy(d, s) } -> std::convertible_to<clev::expected<void>>;
+    }
+  {
+    iface<wrap_t>::copy(&(own::v), rhs.v).or_exit();
+  }
+
+  own& operator=(const own& rhs) noexcept
+    requires requires(wrap_t* d, const wrap_t s) {
+    { iface<wrap_t>::copy(d, s) } -> std::convertible_to<clev::expected<void>>;
+    }
+  {
+    if (this == &rhs)
+      return *this;
+
+    if (*this)
+      iface<wrap_t>::destroy(own::v).or_exit();
+
+    iface<wrap_t>::copy(&(own::v), rhs.v).or_exit();
+
+    return *this;
+  }
+
+  own(const own& rhs)
+    requires(!requires(wrap_t* d, const wrap_t s) {
+    { iface<wrap_t>::copy(d, s) } -> std ::convertible_to<clev::expected<void>>;
+            })
+  = delete;
+
+  own& operator=(const own&)
+    requires(!requires(wrap_t* d, const wrap_t s) {
+    { iface<wrap_t>::copy(d, s) } -> std ::convertible_to<clev::expected<void>>;
+            })
+  = delete;
+
+  own(own&& rhs) noexcept
+  {
+    if (*this)
+      own::destroy(own::v).or_exit();
+
+    own::v = rhs.v;
+
+    rhs.v = own::empty();
+  }
+
+  own& operator=(own&& rhs) noexcept
+  {
+    if (this != &rhs)
+    {
+      if (*this)
+        own::destroy(own::v).or_exit();
+
+      own::v = rhs.v;
+
+      rhs.v = own::empty();
+    };
+
+    return *this;
+  }
+
+  ~own()
+  {
+    if (*this)
+      own::destroy(own::v).or_exit();
+  }
+};
+
+} // namespace clev
+
+static constexpr bool ownxx_own_is_really_needed_v = true;

--- a/lib/include/nngxx/aio.h
+++ b/lib/include/nngxx/aio.h
@@ -29,61 +29,38 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 #pragma once
 
-#include "pars/init.h"
+#include "nngxx/iface/aio.h"
 
-#include "nngxx/ctx.h"
-#include "nngxx/socket.h"
-
-#include <fmt/format.h>
-
-#include <typeinfo>
-#include <variant>
-
-namespace pars::net
+namespace nngxx
 {
 
-/**
- * @brief Represents an nng_socket or nng_ctx view
- */
-class tool_view
+using aio_view = clev::iface<nng_aio*>;
+
+using aio = clev::own<nng_aio*>;
+
+inline static void sleep(nng_duration ms, aio_view& aio) noexcept
 {
-public:
-  /// Construct a tool_view from an nng_ctx view
-  explicit tool_view(nngxx::ctx_view c)
-    : tool_m{c}
-  {
-  }
+  nng_sleep_aio(ms, aio);
+}
 
-  /// Construct a tool_view from an nng_socket view
-  explicit tool_view(nngxx::socket_view s)
-    : tool_m{s}
-  {
-  }
+[[nodiscard]] inline static clev::expected<aio> make_aio(void (*cb)(void*),
+                                                         void* arg) noexcept
+{
+  return aio::alloc(cb, arg).transform_to<aio>();
+}
 
-  /// Get the std::type_info of the underlying variant
-  const std::type_info& type() const
-  {
-    return std::visit([](auto& t) { return std::ref(typeid(t)); }, tool_m);
-  }
+[[nodiscard]] inline static clev::expected<aio>
+make_aio(void (*cb)(void*), void* arg, msg m) noexcept
+{
+  return make_aio(cb, arg).and_then([&](aio op) {
+    op.set_msg(std::move(m));
 
-  /// Get a string that represents the type of the underlying variant
-  const char* who() const { return tool_m.index() == 0 ? "Context" : "Socket"; }
+    return clev::expected{std::move(op)};
+  });
+}
 
-  /// The id of the underlying variant
-  int id() const
-  {
-    return std::visit([](const auto& t) { return t.id(); }, tool_m);
-  }
+} // namespace nngxx
 
-  /// Formatter for debugging purpose
-  auto format_to(fmt::format_context& ctx) const -> decltype(ctx.out())
-  {
-    return fmt::format_to(ctx.out(), "{} #{}", who(), id());
-  }
+static_assert(std::copyable<nngxx::aio_view>);
 
-private:
-  /// The underlying variant that represents either an nng_socket or nng_ctx
-  const std::variant<nngxx::ctx_view, nngxx::socket_view> tool_m;
-};
-
-} // namespace pars::net
+static_assert(nngxx::movable_only_c<nngxx::aio>);

--- a/lib/include/nngxx/ctx.h
+++ b/lib/include/nngxx/ctx.h
@@ -29,61 +29,25 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 #pragma once
 
-#include "pars/init.h"
+#include "nngxx/iface/ctx.h"
 
-#include "nngxx/ctx.h"
-#include "nngxx/socket.h"
-
-#include <fmt/format.h>
-
-#include <typeinfo>
-#include <variant>
-
-namespace pars::net
+namespace nngxx
 {
 
-/**
- * @brief Represents an nng_socket or nng_ctx view
- */
-class tool_view
+using ctx_view = clev::iface<nng_ctx>;
+
+using ctx = clev::own<nng_ctx>;
+
+[[nodiscard]] inline static clev::expected<ctx>
+make_ctx(socket_view& s) noexcept
 {
-public:
-  /// Construct a tool_view from an nng_ctx view
-  explicit tool_view(nngxx::ctx_view c)
-    : tool_m{c}
-  {
-  }
+  auto ret = ctx{};
 
-  /// Construct a tool_view from an nng_socket view
-  explicit tool_view(nngxx::socket_view s)
-    : tool_m{s}
-  {
-  }
+  return ret.open(s).transform_to(std::move(ret));
+}
 
-  /// Get the std::type_info of the underlying variant
-  const std::type_info& type() const
-  {
-    return std::visit([](auto& t) { return std::ref(typeid(t)); }, tool_m);
-  }
+} // namespace nngxx
 
-  /// Get a string that represents the type of the underlying variant
-  const char* who() const { return tool_m.index() == 0 ? "Context" : "Socket"; }
+static_assert(std::copyable<nngxx::ctx_view>);
 
-  /// The id of the underlying variant
-  int id() const
-  {
-    return std::visit([](const auto& t) { return t.id(); }, tool_m);
-  }
-
-  /// Formatter for debugging purpose
-  auto format_to(fmt::format_context& ctx) const -> decltype(ctx.out())
-  {
-    return fmt::format_to(ctx.out(), "{} #{}", who(), id());
-  }
-
-private:
-  /// The underlying variant that represents either an nng_socket or nng_ctx
-  const std::variant<nngxx::ctx_view, nngxx::socket_view> tool_m;
-};
-
-} // namespace pars::net
+static_assert(nngxx::movable_only_c<nngxx::ctx>);

--- a/lib/include/nngxx/dialer.h
+++ b/lib/include/nngxx/dialer.h
@@ -29,61 +29,25 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 #pragma once
 
-#include "pars/init.h"
+#include "nngxx/iface/dialer.h"
 
-#include "nngxx/ctx.h"
-#include "nngxx/socket.h"
-
-#include <fmt/format.h>
-
-#include <typeinfo>
-#include <variant>
-
-namespace pars::net
+namespace nngxx
 {
 
-/**
- * @brief Represents an nng_socket or nng_ctx view
- */
-class tool_view
+using dialer_view = clev::iface<nng_dialer>;
+
+using dialer = clev::own<nng_dialer>;
+
+[[nodiscard]] inline static clev::expected<dialer>
+make_dialer(socket_view& s, const char* addr) noexcept
 {
-public:
-  /// Construct a tool_view from an nng_ctx view
-  explicit tool_view(nngxx::ctx_view c)
-    : tool_m{c}
-  {
-  }
+  auto ret = dialer{};
 
-  /// Construct a tool_view from an nng_socket view
-  explicit tool_view(nngxx::socket_view s)
-    : tool_m{s}
-  {
-  }
+  return ret.create(s, addr).transform_to(std::move(ret));
+}
 
-  /// Get the std::type_info of the underlying variant
-  const std::type_info& type() const
-  {
-    return std::visit([](auto& t) { return std::ref(typeid(t)); }, tool_m);
-  }
+} // namespace nngxx
 
-  /// Get a string that represents the type of the underlying variant
-  const char* who() const { return tool_m.index() == 0 ? "Context" : "Socket"; }
+static_assert(std::copyable<nngxx::dialer_view>);
 
-  /// The id of the underlying variant
-  int id() const
-  {
-    return std::visit([](const auto& t) { return t.id(); }, tool_m);
-  }
-
-  /// Formatter for debugging purpose
-  auto format_to(fmt::format_context& ctx) const -> decltype(ctx.out())
-  {
-    return fmt::format_to(ctx.out(), "{} #{}", who(), id());
-  }
-
-private:
-  /// The underlying variant that represents either an nng_socket or nng_ctx
-  const std::variant<nngxx::ctx_view, nngxx::socket_view> tool_m;
-};
-
-} // namespace pars::net
+static_assert(nngxx::movable_only_c<nngxx::dialer>);

--- a/lib/include/nngxx/err.h
+++ b/lib/include/nngxx/err.h
@@ -1,0 +1,142 @@
+/*
+Copyright (c) 2025 Giuseppe Roberti.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+this list of conditions and the following disclaimer in the documentation and/or
+other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors
+may be used to endorse or promote products derived from this software without
+specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+#pragma once
+
+#include "clev/err.h"
+
+#include <fmt/format.h>
+#include <nng/nng.h>
+
+#include <expected>
+
+namespace nngxx
+{
+
+enum class err : int;
+
+[[nodiscard]] inline static const std::error_category& error_category() noexcept
+{
+  static struct : std::error_category
+  {
+    virtual const char* name() const noexcept override { return "nngxx"; }
+
+    virtual std::string message(int e) const override
+    {
+      return nng_strerror(e);
+    }
+  } error_category;
+
+  return error_category;
+}
+
+[[nodiscard]] inline std::error_code make_error_code(err e) noexcept
+{
+  return std::error_code(static_cast<int>(e), error_category());
+}
+
+} // namespace nngxx
+
+template<>
+struct std::is_error_code_enum<nngxx::err> : std::true_type
+{
+};
+
+namespace nngxx
+{
+
+enum class err
+{
+  success = 0,
+  intr = NNG_EINTR,
+  nomem = NNG_ENOMEM,
+  inval = NNG_EINVAL,
+  busy = NNG_EBUSY,
+  timedout = NNG_ETIMEDOUT,
+  connrefused = NNG_ECONNREFUSED,
+  closed = NNG_ECLOSED,
+  again = NNG_EAGAIN,
+  notsup = NNG_ENOTSUP,
+  addrinuse = NNG_EADDRINUSE,
+  state = NNG_ESTATE,
+  noent = NNG_ENOENT,
+  proto = NNG_EPROTO,
+  unreachable = NNG_EUNREACHABLE,
+  addrinval = NNG_EADDRINVAL,
+  perm = NNG_EPERM,
+  msgsize = NNG_EMSGSIZE,
+  connaborted = NNG_ECONNABORTED,
+  connreset = NNG_ECONNRESET,
+  canceled = NNG_ECANCELED,
+  nofiles = NNG_ENOFILES,
+  nospc = NNG_ENOSPC,
+  exist = NNG_EEXIST,
+  readonly = NNG_EREADONLY,
+  writeonly = NNG_EWRITEONLY,
+  crypto = NNG_ECRYPTO,
+  peerauth = NNG_EPEERAUTH,
+  noarg = NNG_ENOARG,
+  ambiguous = NNG_EAMBIGUOUS,
+  badtype = NNG_EBADTYPE,
+  connshut = NNG_ECONNSHUT,
+  internal = NNG_EINTERNAL,
+  syserr = NNG_ESYSERR,
+  tranerr = NNG_ETRANERR
+};
+
+template<typename ret_t, typename arg_t, typename... args_t>
+[[nodiscard]] inline clev::expected<std::remove_pointer_t<arg_t>>
+make(ret_t (*f)(arg_t, args_t...), args_t... args) noexcept
+{
+  std::remove_pointer_t<arg_t> x;
+
+  return clev::make_expected<err>(f(&x, args...)).transform_to(std::move(x));
+}
+
+template<typename ret_t, typename... args_t>
+[[nodiscard]] inline clev::expected<void> invoke(ret_t (*f)(args_t...),
+                                                 args_t... args) noexcept
+{
+  return clev::make_expected<err>(f(args...));
+}
+
+template<typename... args_t>
+[[nodiscard]] inline clev::expected<void> invoke(void (*f)(args_t...),
+                                                 args_t... args) noexcept
+{
+  f(args...);
+
+  return {};
+}
+
+} // namespace nngxx
+
+static_assert(std::convertible_to<nngxx::err, std::error_code>);
+
+static_assert(std::constructible_from<std::error_code, nngxx::err>);

--- a/lib/include/nngxx/iface/ctx.h
+++ b/lib/include/nngxx/iface/ctx.h
@@ -29,61 +29,37 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 #pragma once
 
-#include "pars/init.h"
-
-#include "nngxx/ctx.h"
+#include "nngxx/aio.h"
+#include "nngxx/iface/value.h"
 #include "nngxx/socket.h"
 
-#include <fmt/format.h>
+#include <nng/nng.h>
 
-#include <typeinfo>
-#include <variant>
-
-namespace pars::net
+template<>
+struct clev::iface<nng_ctx> : nngxx::value<nng_ctx>
 {
+  using value::value;
 
-/**
- * @brief Represents an nng_socket or nng_ctx view
- */
-class tool_view
-{
-public:
-  /// Construct a tool_view from an nng_ctx view
-  explicit tool_view(nngxx::ctx_view c)
-    : tool_m{c}
+  [[nodiscard]] inline static nng_ctx empty() noexcept
   {
+    return NNG_CTX_INITIALIZER;
+  };
+
+  [[nodiscard]] inline static clev::expected<void> destroy(nng_ctx v) noexcept
+  {
+    return nngxx::invoke(nng_ctx_close, v);
   }
 
-  /// Construct a tool_view from an nng_socket view
-  explicit tool_view(nngxx::socket_view s)
-    : tool_m{s}
+  [[nodiscard]] inline int id() const noexcept { return nng_ctx_id(v); }
+
+  inline void send(nngxx::aio_view& a) noexcept { nng_ctx_send(v, a); }
+
+  inline void recv(nngxx::aio_view& a) noexcept { nng_ctx_recv(v, a); }
+
+  [[nodiscard]] inline clev::expected<void> open(nngxx::socket_view& s) noexcept
   {
+    return nngxx::invoke(nng_ctx_open, &v, static_cast<nng_socket>(s));
   }
-
-  /// Get the std::type_info of the underlying variant
-  const std::type_info& type() const
-  {
-    return std::visit([](auto& t) { return std::ref(typeid(t)); }, tool_m);
-  }
-
-  /// Get a string that represents the type of the underlying variant
-  const char* who() const { return tool_m.index() == 0 ? "Context" : "Socket"; }
-
-  /// The id of the underlying variant
-  int id() const
-  {
-    return std::visit([](const auto& t) { return t.id(); }, tool_m);
-  }
-
-  /// Formatter for debugging purpose
-  auto format_to(fmt::format_context& ctx) const -> decltype(ctx.out())
-  {
-    return fmt::format_to(ctx.out(), "{} #{}", who(), id());
-  }
-
-private:
-  /// The underlying variant that represents either an nng_socket or nng_ctx
-  const std::variant<nngxx::ctx_view, nngxx::socket_view> tool_m;
 };
 
-} // namespace pars::net
+static_assert(nngxx_socket_is_really_needed_v);

--- a/lib/include/nngxx/iface/dialer.h
+++ b/lib/include/nngxx/iface/dialer.h
@@ -29,61 +29,39 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 #pragma once
 
-#include "pars/init.h"
-
-#include "nngxx/ctx.h"
+#include "nngxx/err.h"
+#include "nngxx/iface/value.h"
 #include "nngxx/socket.h"
 
-#include <fmt/format.h>
+#include <nng/nng.h>
 
-#include <typeinfo>
-#include <variant>
-
-namespace pars::net
+template<>
+struct clev::iface<nng_dialer> : nngxx::value<nng_dialer>
 {
+  using value::value;
 
-/**
- * @brief Represents an nng_socket or nng_ctx view
- */
-class tool_view
-{
-public:
-  /// Construct a tool_view from an nng_ctx view
-  explicit tool_view(nngxx::ctx_view c)
-    : tool_m{c}
+  [[nodiscard]] inline static nng_dialer empty() noexcept
   {
+    return NNG_DIALER_INITIALIZER;
+  };
+
+  [[nodiscard]] inline static clev::expected<void>
+  destroy(nng_dialer d) noexcept
+  {
+    return nngxx::invoke(nng_dialer_close, d);
   }
 
-  /// Construct a tool_view from an nng_socket view
-  explicit tool_view(nngxx::socket_view s)
-    : tool_m{s}
+  [[nodiscard]] inline clev::expected<void> create(nngxx::socket_view& s,
+                                                   const char* addr) noexcept
   {
+    return nngxx::invoke(nng_dialer_create, &v, static_cast<nng_socket>(s),
+                         addr);
   }
 
-  /// Get the std::type_info of the underlying variant
-  const std::type_info& type() const
+  [[nodiscard]] inline clev::expected<void> start(int flags = 0) noexcept
   {
-    return std::visit([](auto& t) { return std::ref(typeid(t)); }, tool_m);
+    return nngxx::invoke(nng_dialer_start, v, flags);
   }
-
-  /// Get a string that represents the type of the underlying variant
-  const char* who() const { return tool_m.index() == 0 ? "Context" : "Socket"; }
-
-  /// The id of the underlying variant
-  int id() const
-  {
-    return std::visit([](const auto& t) { return t.id(); }, tool_m);
-  }
-
-  /// Formatter for debugging purpose
-  auto format_to(fmt::format_context& ctx) const -> decltype(ctx.out())
-  {
-    return fmt::format_to(ctx.out(), "{} #{}", who(), id());
-  }
-
-private:
-  /// The underlying variant that represents either an nng_socket or nng_ctx
-  const std::variant<nngxx::ctx_view, nngxx::socket_view> tool_m;
 };
 
-} // namespace pars::net
+static_assert(nngxx_socket_is_really_needed_v);

--- a/lib/include/nngxx/iface/value.h
+++ b/lib/include/nngxx/iface/value.h
@@ -1,0 +1,137 @@
+/*
+Copyright (c) 2025 Giuseppe Roberti.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+this list of conditions and the following disclaimer in the documentation and/or
+other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors
+may be used to endorse or promote products derived from this software without
+specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+#pragma once
+
+#include "clev/own.h"
+#include "clev/value.h"
+#include "nngxx/concept.h"
+#include "nngxx/opt.h"
+#include "nngxx/opt_getter.h"
+#include "nngxx/opt_setter.h"
+
+#include <type_traits>
+
+namespace nngxx
+{
+
+template<nng_c nng_t>
+struct value : clev::value<nng_t>
+{
+  using parent = clev::value<nng_t>;
+
+  using parent::parent;
+
+  using nng_type = parent::value_type;
+
+  [[nodiscard]] inline static bool is_valid(nng_type v) noexcept
+  {
+    if constexpr (std::is_pointer_v<nng_type>)
+      return v != nullptr;
+    else
+      return v.id != 0;
+  }
+
+  /// @name options setters
+
+  [[nodiscard]] inline clev::expected<void>
+  set_recv_timeout(nng_duration d) noexcept
+  {
+    return set_option<opt::recvtimeo>(d);
+  }
+
+  [[nodiscard]] inline clev::expected<void>
+  set_send_timeout(nng_duration d) noexcept
+  {
+    return set_option<opt::sendtimeo>(d);
+  }
+
+  [[nodiscard]] inline clev::expected<void>
+  set_req_resend_time(nng_duration d) noexcept
+  {
+    return set_option<opt::req_resend_time>(d);
+  }
+
+  [[nodiscard]] inline clev::expected<void>
+  set_req_resend_tick(nng_duration d) noexcept
+  {
+    return set_option<opt::req_resend_tick>(d);
+  }
+
+  /// @name options getters
+
+  // TODO: use me
+  [[nodiscard]] inline clev::expected<const char*>
+  get_sock_name() const noexcept
+  {
+    return get_option<opt::sockname>();
+  }
+
+  [[nodiscard]] inline clev::expected<nng_duration>
+  get_recv_timeout() const noexcept
+  {
+    return get_option<opt::recvtimeo>();
+  }
+
+  [[nodiscard]] inline clev::expected<nng_duration>
+  get_send_timeout() const noexcept
+  {
+    return get_option<opt::sendtimeo>();
+  }
+
+  [[nodiscard]] inline clev::expected<nng_duration>
+  get_req_resend_time() const noexcept
+  {
+    return get_option<opt::req_resend_time>();
+  }
+
+  [[nodiscard]] inline clev::expected<nng_duration>
+  get_req_resend_tick() const noexcept
+  {
+    return get_option<opt::req_resend_tick>();
+  }
+
+private:
+  template<opt opt_v, nng_value_c nng_value_t>
+  [[nodiscard]] inline clev::expected<void> set_option(nng_value_t val)
+  {
+    return opt_setter<opt_v, nng_type>{}(parent::v, val);
+  }
+
+  template<opt opt_v>
+  [[nodiscard]] inline clev::expected<opt_to_nng_type_t<opt_v>>
+  get_option() const
+  {
+    return opt_getter<opt_v, nng_type>{}(parent::v);
+  }
+};
+
+} // namespace nngxx
+
+static_assert(ownxx_own_is_really_needed_v);

--- a/lib/include/nngxx/listener.h
+++ b/lib/include/nngxx/listener.h
@@ -29,61 +29,23 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 #pragma once
 
-#include "pars/init.h"
+#include "nngxx/iface/listener.h"
 
-#include "nngxx/ctx.h"
-#include "nngxx/socket.h"
-
-#include <fmt/format.h>
-
-#include <typeinfo>
-#include <variant>
-
-namespace pars::net
+namespace nngxx
 {
 
-/**
- * @brief Represents an nng_socket or nng_ctx view
- */
-class tool_view
+using listener_view = clev::iface<nng_listener>;
+
+using listener = clev::own<nng_listener>;
+
+[[nodiscard]] inline static clev::expected<listener>
+make_listener(socket_view& s, const char* addr) noexcept
 {
-public:
-  /// Construct a tool_view from an nng_ctx view
-  explicit tool_view(nngxx::ctx_view c)
-    : tool_m{c}
-  {
-  }
+  return listener::create(s, addr).transform_to<listener>();
+}
 
-  /// Construct a tool_view from an nng_socket view
-  explicit tool_view(nngxx::socket_view s)
-    : tool_m{s}
-  {
-  }
+} // namespace nngxx
 
-  /// Get the std::type_info of the underlying variant
-  const std::type_info& type() const
-  {
-    return std::visit([](auto& t) { return std::ref(typeid(t)); }, tool_m);
-  }
+static_assert(std::copyable<nngxx::listener_view>);
 
-  /// Get a string that represents the type of the underlying variant
-  const char* who() const { return tool_m.index() == 0 ? "Context" : "Socket"; }
-
-  /// The id of the underlying variant
-  int id() const
-  {
-    return std::visit([](const auto& t) { return t.id(); }, tool_m);
-  }
-
-  /// Formatter for debugging purpose
-  auto format_to(fmt::format_context& ctx) const -> decltype(ctx.out())
-  {
-    return fmt::format_to(ctx.out(), "{} #{}", who(), id());
-  }
-
-private:
-  /// The underlying variant that represents either an nng_socket or nng_ctx
-  const std::variant<nngxx::ctx_view, nngxx::socket_view> tool_m;
-};
-
-} // namespace pars::net
+static_assert(nngxx::movable_only_c<nngxx::listener>);

--- a/lib/include/nngxx/msg.h
+++ b/lib/include/nngxx/msg.h
@@ -29,61 +29,25 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 #pragma once
 
-#include "pars/init.h"
+#include "nngxx/iface/msg.h"
 
-#include "nngxx/ctx.h"
-#include "nngxx/socket.h"
-
-#include <fmt/format.h>
-
-#include <typeinfo>
-#include <variant>
-
-namespace pars::net
+namespace nngxx
 {
 
-/**
- * @brief Represents an nng_socket or nng_ctx view
- */
-class tool_view
+using msg_view = clev::iface<nng_msg*>;
+
+using msg = clev::own<nng_msg*>;
+
+[[nodiscard]] inline static clev::expected<msg>
+make_msg(std::size_t sz) noexcept
 {
-public:
-  /// Construct a tool_view from an nng_ctx view
-  explicit tool_view(nngxx::ctx_view c)
-    : tool_m{c}
-  {
-  }
+  auto ret = msg{};
 
-  /// Construct a tool_view from an nng_socket view
-  explicit tool_view(nngxx::socket_view s)
-    : tool_m{s}
-  {
-  }
+  return ret.alloc(sz).transform_to(std::move(ret));
+}
 
-  /// Get the std::type_info of the underlying variant
-  const std::type_info& type() const
-  {
-    return std::visit([](auto& t) { return std::ref(typeid(t)); }, tool_m);
-  }
+} // namespace nngxx
 
-  /// Get a string that represents the type of the underlying variant
-  const char* who() const { return tool_m.index() == 0 ? "Context" : "Socket"; }
+static_assert(std::copyable<nngxx::msg_view>);
 
-  /// The id of the underlying variant
-  int id() const
-  {
-    return std::visit([](const auto& t) { return t.id(); }, tool_m);
-  }
-
-  /// Formatter for debugging purpose
-  auto format_to(fmt::format_context& ctx) const -> decltype(ctx.out())
-  {
-    return fmt::format_to(ctx.out(), "{} #{}", who(), id());
-  }
-
-private:
-  /// The underlying variant that represents either an nng_socket or nng_ctx
-  const std::variant<nngxx::ctx_view, nngxx::socket_view> tool_m;
-};
-
-} // namespace pars::net
+static_assert(std::copyable<nngxx::msg>);

--- a/lib/include/nngxx/msg_body.h
+++ b/lib/include/nngxx/msg_body.h
@@ -1,0 +1,158 @@
+/*
+Copyright (c) 2025 Giuseppe Roberti.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+this list of conditions and the following disclaimer in the documentation and/or
+other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors
+may be used to endorse or promote products derived from this software without
+specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+#pragma once
+
+#include "nngxx/concept.h"
+#include "nngxx/err.h"
+#include "nngxx/msg.h"
+
+namespace nngxx
+{
+
+struct msg_body
+{
+  msg_body(nng_msg* m) noexcept
+    : m{m}
+  {
+  }
+
+  [[nodiscard]] inline std::size_t size() const noexcept
+  {
+    return nng_msg_len(m);
+  }
+
+  template<typename char_t>
+  [[nodiscard]] inline char_t* data() noexcept
+  {
+    return static_cast<char_t*>(nng_msg_body(m));
+  }
+
+  template<typename char_t>
+  [[nodiscard]] inline char_t* const data() const noexcept
+  {
+    return static_cast<char_t* const>(nng_msg_body(m));
+  }
+
+  template<uint_c uint_t>
+  [[nodiscard]] inline clev::expected<uint_t> append() noexcept
+  {
+    uint_t x;
+
+    int (*append)(nng_msg*, uint_t*);
+
+    if constexpr (std::is_same_v<uint_t, uint16_t>)
+    {
+      append = nng_msg_append;
+    }
+    else if constexpr (std::is_same_v<uint_t, uint32_t>)
+    {
+      append = nng_msg_trim_u32;
+    }
+    else if constexpr (std::is_same_v<uint_t, uint64_t>)
+    {
+      append = nng_msg_trim_u64;
+    }
+
+    return nngxx::invoke(append, m, &x);
+  }
+
+  template<uint_c uint_t>
+  [[nodiscard]] inline clev::expected<uint_t> trim() noexcept
+  {
+    uint_t x;
+
+    int (*trim)(nng_msg*, uint_t*);
+
+    if constexpr (std::is_same_v<uint_t, uint16_t>)
+    {
+      trim = nng_msg_trim_u16;
+    }
+    else if constexpr (std::is_same_v<uint_t, uint32_t>)
+    {
+      trim = nng_msg_trim_u32;
+    }
+    else if constexpr (std::is_same_v<uint_t, uint64_t>)
+    {
+      trim = nng_msg_trim_u64;
+    }
+
+    return nngxx::invoke(trim, m, &x);
+  }
+
+  [[nodiscard]] inline clev::expected<void> trim(std::size_t sz) noexcept
+  {
+    return nngxx::invoke(nng_msg_trim, m, sz);
+  }
+
+  template<uint_c uint_t>
+  [[nodiscard]] inline clev::expected<uint_t> chop() noexcept
+  {
+    uint_t x;
+
+    int (*chop)(nng_msg*, uint_t*);
+
+    if constexpr (std::is_same_v<uint_t, uint16_t>)
+    {
+      chop = nng_msg_chop;
+    }
+    else if constexpr (std::is_same_v<uint_t, uint32_t>)
+    {
+      chop = nng_msg_chop_u32;
+    }
+    else if constexpr (std::is_same_v<uint_t, uint64_t>)
+    {
+      chop = nng_msg_chop_u64;
+    }
+
+    return nngxx::invoke(chop, m, &x);
+  }
+
+  [[nodiscard]] inline clev::expected<void> chop(std::size_t sz) noexcept
+  {
+    return nngxx::invoke(nng_msg_chop, m, sz);
+  }
+
+private:
+  nng_msg* m;
+};
+
+} // namespace nngxx
+
+nngxx::msg_body nngxx::msg_view::body() noexcept
+{
+  return nngxx::msg_body{v};
+}
+
+const nngxx::msg_body nngxx::msg_view::body() const noexcept
+{
+  return nngxx::msg_body{v};
+}
+
+static_assert(std::copyable<nngxx::msg_body>);

--- a/lib/include/nngxx/opt.h
+++ b/lib/include/nngxx/opt.h
@@ -1,0 +1,292 @@
+/*
+Copyright (c) 2025 Giuseppe Roberti.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+this list of conditions and the following disclaimer in the documentation and/or
+other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors
+may be used to endorse or promote products derived from this software without
+specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+#pragma once
+
+#include <nng/nng.h>
+#include <nng/protocol/reqrep0/req.h>
+
+namespace nngxx
+{
+
+enum class opt
+{
+  sockname,
+  raw,
+  // proto, // deprecated
+  // protoname, // deprecated
+  // peer, // deprecated
+  // peername, // deprecated
+  recvbuf,
+  sendbuf,
+  recvfd,
+  sendfd,
+  recvtimeo,
+  sendtimeo,
+  locaddr,
+  remaddr,
+  url,
+  maxttl,
+  recvmaxsz,
+  reconnmint,
+  reconnmaxt,
+  peergid,
+  peerpid,
+  peeruid,
+  peerzoneid,
+  req_resend_time,
+  req_resend_tick
+};
+
+enum class opt_overload
+{
+  integer,
+  boolean,
+  string,
+  size,
+  sockaddr,
+  duration,
+  uint64
+};
+
+template<opt o>
+[[nodiscard]] static constexpr const char* opt_to_nng_value() noexcept
+{
+  if constexpr (o == opt::sockname)
+  {
+    return NNG_OPT_SOCKNAME;
+  }
+  else if constexpr (o == opt::raw)
+  {
+    return NNG_OPT_RAW;
+  }
+  else if constexpr (o == opt::recvbuf)
+  {
+    return NNG_OPT_RECVBUF;
+  }
+  else if constexpr (o == opt::sendbuf)
+  {
+    return NNG_OPT_SENDBUF;
+  }
+  else if constexpr (o == opt::recvfd)
+  {
+    return NNG_OPT_RECVFD;
+  }
+  else if constexpr (o == opt::sendfd)
+  {
+    return NNG_OPT_SENDFD;
+  }
+  else if constexpr (o == opt::recvtimeo)
+  {
+    return NNG_OPT_RECVTIMEO;
+  }
+  else if constexpr (o == opt::sendtimeo)
+  {
+    return NNG_OPT_SENDTIMEO;
+  }
+  else if constexpr (o == opt::locaddr)
+  {
+    return NNG_OPT_LOCADDR;
+  }
+  else if constexpr (o == opt::remaddr)
+  {
+    return NNG_OPT_REMADDR;
+  }
+  else if constexpr (o == opt::url)
+  {
+    return NNG_OPT_URL;
+  }
+  else if constexpr (o == opt::maxttl)
+  {
+    return NNG_OPT_MAXTTL;
+  }
+  else if constexpr (o == opt::recvmaxsz)
+  {
+    return NNG_OPT_RECVMAXSZ;
+  }
+  else if constexpr (o == opt::reconnmint)
+  {
+    return NNG_OPT_RECONNMINT;
+  }
+  else if constexpr (o == opt::reconnmaxt)
+  {
+    return NNG_OPT_RECONNMAXT;
+  }
+  else if constexpr (o == opt::peergid)
+  {
+    return NNG_OPT_PEER_GID;
+  }
+  else if constexpr (o == opt::peerpid)
+  {
+    return NNG_OPT_PEER_UID;
+  }
+  else if constexpr (o == opt::peeruid)
+  {
+    return NNG_OPT_PEER_UID;
+  }
+  else if constexpr (o == opt::peerzoneid)
+  {
+    return NNG_OPT_PEER_ZONEID;
+  }
+  else if constexpr (o == opt::req_resend_time)
+  {
+    return NNG_OPT_REQ_RESENDTIME;
+  }
+  else if constexpr (o == opt::req_resend_tick)
+  {
+    return NNG_OPT_REQ_RESENDTICK;
+  }
+}
+
+template<opt o>
+[[nodiscard]] static constexpr opt_overload opt_to_nng_overload() noexcept
+{
+  if constexpr (o == opt::sockname)
+  {
+    return opt_overload::string;
+  }
+  else if constexpr (o == opt::raw)
+  {
+    return opt_overload::boolean;
+  }
+  else if constexpr (o == opt::recvbuf)
+  {
+    return opt_overload::integer;
+  }
+  else if constexpr (o == opt::sendbuf)
+  {
+    return opt_overload::integer;
+  }
+  else if constexpr (o == opt::recvfd)
+  {
+    return opt_overload::integer;
+  }
+  else if constexpr (o == opt::sendfd)
+  {
+    return opt_overload::integer;
+  }
+  else if constexpr (o == opt::recvtimeo)
+  {
+    return opt_overload::duration;
+  }
+  else if constexpr (o == opt::sendtimeo)
+  {
+    return opt_overload::duration;
+  }
+  else if constexpr (o == opt::locaddr)
+  {
+    return opt_overload::sockaddr;
+  }
+  else if constexpr (o == opt::remaddr)
+  {
+    return opt_overload::sockaddr;
+  }
+  else if constexpr (o == opt::url)
+  {
+    return opt_overload::string;
+  }
+  else if constexpr (o == opt::maxttl)
+  {
+    return opt_overload::integer;
+  }
+  else if constexpr (o == opt::recvmaxsz)
+  {
+    return opt_overload::size;
+  }
+  else if constexpr (o == opt::reconnmint)
+  {
+    return opt_overload::duration;
+  }
+  else if constexpr (o == opt::reconnmaxt)
+  {
+    return opt_overload::duration;
+  }
+  else if constexpr (o == opt::peergid)
+  {
+    return opt_overload::uint64;
+  }
+  else if constexpr (o == opt::peerpid)
+  {
+    return opt_overload::uint64;
+  }
+  else if constexpr (o == opt::peeruid)
+  {
+    return opt_overload::uint64;
+  }
+  else if constexpr (o == opt::peerzoneid)
+  {
+    return opt_overload::uint64;
+  }
+  else if constexpr (o == opt::req_resend_time)
+  {
+    return opt_overload::duration;
+  }
+  else if constexpr (o == opt::req_resend_tick)
+  {
+    return opt_overload::duration;
+  }
+}
+
+template<opt o>
+struct opt_to_nng_type;
+
+template<opt o>
+using opt_to_nng_type_t = opt_to_nng_type<o>::return_type;
+
+template<>
+struct opt_to_nng_type<opt::sockname>
+{
+  using return_type = const char*;
+};
+
+template<>
+struct opt_to_nng_type<opt::recvtimeo>
+{
+  using return_type = nng_duration;
+};
+
+template<>
+struct opt_to_nng_type<opt::sendtimeo>
+{
+  using return_type = nng_duration;
+};
+
+template<>
+struct opt_to_nng_type<opt::req_resend_time>
+{
+  using return_type = nng_duration;
+};
+
+template<>
+struct opt_to_nng_type<opt::req_resend_tick>
+{
+  using return_type = nng_duration;
+};
+
+} // namespace nngxx

--- a/lib/include/nngxx/opt_getter.h
+++ b/lib/include/nngxx/opt_getter.h
@@ -1,0 +1,145 @@
+/*
+Copyright (c) 2025 Giuseppe Roberti.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+this list of conditions and the following disclaimer in the documentation and/or
+other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors
+may be used to endorse or promote products derived from this software without
+specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+#pragma once
+
+#include "nngxx/concept.h"
+#include "nngxx/err.h"
+#include "nngxx/opt.h"
+
+namespace nngxx
+{
+
+template<opt opt_v, nng_with_get_opt_c nng_t>
+struct opt_getter
+{
+  using nng_type = nng_t;
+
+  static constexpr auto opt = opt_to_nng_value<opt_v>();
+
+  static constexpr auto overload = opt_to_nng_overload<opt_v>();
+
+  using return_type = opt_to_nng_type_t<opt_v>;
+
+  [[nodiscard]] inline clev::expected<return_type>
+  operator()(nng_type obj) noexcept
+  {
+    int (*get)(nng_type, const char*, return_type*);
+
+    if constexpr (std::is_same_v<nng_type, nng_socket>)
+    {
+      if constexpr (overload == opt_overload::boolean)
+        get = nng_socket_get_bool;
+      else if constexpr (overload == opt_overload::integer)
+        get = nng_socket_get_int;
+      else if constexpr (overload == opt_overload::size)
+        get = nng_socket_get_size;
+      else if constexpr (overload == opt_overload::uint64)
+        get = nng_socket_get_uint64;
+      else if constexpr (overload == opt_overload::string)
+        get = nng_socket_get_string;
+      else if constexpr (overload == opt_overload::duration)
+        get = nng_socket_get_ms;
+      else if constexpr (overload == opt_overload::sockaddr)
+        get = nng_socket_get_addr;
+    }
+    else if constexpr (std::is_same_v<nng_type, nng_ctx>)
+    {
+      if constexpr (overload == opt_overload::boolean)
+        get = nng_ctx_get_bool;
+      else if constexpr (overload == opt_overload::integer)
+        get = nng_ctx_get_int;
+      else if constexpr (overload == opt_overload::size)
+        get = nng_ctx_get_size;
+      else if constexpr (overload == opt_overload::uint64)
+        get = nng_ctx_get_uint64;
+      else if constexpr (overload == opt_overload::string)
+        get = nng_ctx_get_string;
+      else if constexpr (overload == opt_overload::duration)
+        get = nng_ctx_get_ms;
+    }
+    else if constexpr (std::is_same_v<nng_type, nng_listener>)
+    {
+      if constexpr (overload == opt_overload::boolean)
+        get = nng_listener_get_bool;
+      else if constexpr (overload == opt_overload::integer)
+        get = nng_listener_get_int;
+      else if constexpr (overload == opt_overload::size)
+        get = nng_listener_get_size;
+      else if constexpr (overload == opt_overload::uint64)
+        get = nng_listener_get_uint64;
+      else if constexpr (overload == opt_overload::string)
+        get = nng_listener_get_string;
+      else if constexpr (overload == opt_overload::duration)
+        get = nng_listener_get_ms;
+      else if constexpr (overload == opt_overload::sockaddr)
+        get = nng_listener_get_addr;
+    }
+    else if constexpr (std::is_same_v<nng_type, nng_dialer>)
+    {
+      if constexpr (overload == opt_overload::boolean)
+        get = nng_dialer_get_bool;
+      else if constexpr (overload == opt_overload::integer)
+        get = nng_dialer_get_int;
+      else if constexpr (overload == opt_overload::size)
+        get = nng_dialer_get_size;
+      else if constexpr (overload == opt_overload::uint64)
+        get = nng_dialer_get_uint64;
+      else if constexpr (overload == opt_overload::string)
+        get = nng_dialer_get_string;
+      else if constexpr (overload == opt_overload::duration)
+        get = nng_dialer_get_ms;
+      else if constexpr (overload == opt_overload::sockaddr)
+        get = nng_dialer_get_addr;
+    }
+    else if constexpr (std::is_same_v<nng_type, nng_pipe>)
+    {
+      if constexpr (overload == opt_overload::boolean)
+        get = nng_pipe_get_bool;
+      else if constexpr (overload == opt_overload::integer)
+        get = nng_pipe_get_int;
+      else if constexpr (overload == opt_overload::size)
+        get = nng_pipe_get_size;
+      else if constexpr (overload == opt_overload::uint64)
+        get = nng_pipe_get_uint64;
+      else if constexpr (overload == opt_overload::string)
+        get = nng_pipe_get_string;
+      else if constexpr (overload == opt_overload::duration)
+        get = nng_pipe_get_ms;
+      else if constexpr (overload == opt_overload::sockaddr)
+        get = nng_pipe_get_addr;
+    }
+
+    return_type val;
+
+    return nngxx::invoke(get, obj, opt, &val).transform_to(std::move(val));
+  }
+};
+
+} // namespace nngxx

--- a/lib/include/nngxx/opt_setter.h
+++ b/lib/include/nngxx/opt_setter.h
@@ -1,0 +1,125 @@
+/*
+Copyright (c) 2025 Giuseppe Roberti.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+this list of conditions and the following disclaimer in the documentation and/or
+other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors
+may be used to endorse or promote products derived from this software without
+specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+#pragma once
+
+#include "nngxx/concept.h"
+#include "nngxx/err.h"
+#include "nngxx/opt.h"
+
+namespace nngxx
+{
+
+template<opt opt_v, nng_with_set_opt_c nng_t>
+struct opt_setter
+{
+  using nng_type = nng_t;
+
+  static constexpr auto opt = opt_to_nng_value<opt_v>();
+
+  static constexpr auto overload = opt_to_nng_overload<opt_v>();
+
+  template<nng_value_c nng_value_t>
+  [[nodiscard]] inline clev::expected<void> operator()(nng_type obj,
+                                                       nng_value_t val) noexcept
+  {
+    int (*set)(nng_type, const char*, nng_value_t);
+
+    if constexpr (std::is_same_v<nng_type, nng_socket>)
+    {
+      if constexpr (overload == opt_overload::boolean)
+        set = nng_socket_set_bool;
+      else if constexpr (overload == opt_overload::integer)
+        set = nng_socket_set_int;
+      else if constexpr (overload == opt_overload::size)
+        set = nng_socket_set_size;
+      else if constexpr (overload == opt_overload::uint64)
+        set = nng_socket_set_uint64;
+      else if constexpr (overload == opt_overload::string)
+        set = nng_socket_set_string;
+      else if constexpr (overload == opt_overload::duration)
+        set = nng_socket_set_ms;
+      else if constexpr (overload == opt_overload::sockaddr)
+        set = nng_socket_set_addr;
+    }
+    else if constexpr (std::is_same_v<nng_type, nng_ctx>)
+    {
+      if constexpr (overload == opt_overload::boolean)
+        set = nng_ctx_set_bool;
+      else if constexpr (overload == opt_overload::integer)
+        set = nng_ctx_set_int;
+      else if constexpr (overload == opt_overload::size)
+        set = nng_ctx_set_size;
+      else if constexpr (overload == opt_overload::uint64)
+        set = nng_ctx_set_uint64;
+      else if constexpr (overload == opt_overload::string)
+        set = nng_ctx_set_string;
+      else if constexpr (overload == opt_overload::duration)
+        set = nng_ctx_set_ms;
+    }
+    else if constexpr (std::is_same_v<nng_type, nng_listener>)
+    {
+      if constexpr (overload == opt_overload::boolean)
+        set = nng_listener_set_bool;
+      else if constexpr (overload == opt_overload::integer)
+        set = nng_listener_set_int;
+      else if constexpr (overload == opt_overload::size)
+        set = nng_listener_set_size;
+      else if constexpr (overload == opt_overload::uint64)
+        set = nng_listener_set_uint64;
+      else if constexpr (overload == opt_overload::string)
+        set = nng_listener_set_string;
+      else if constexpr (overload == opt_overload::duration)
+        set = nng_listener_set_ms;
+      else if constexpr (overload == opt_overload::sockaddr)
+        set = nng_listener_set_addr;
+    }
+    else if constexpr (std::is_same_v<nng_type, nng_dialer>)
+    {
+      if constexpr (overload == opt_overload::boolean)
+        set = nng_dialer_set_bool;
+      else if constexpr (overload == opt_overload::integer)
+        set = nng_dialer_set_int;
+      else if constexpr (overload == opt_overload::size)
+        set = nng_dialer_set_size;
+      else if constexpr (overload == opt_overload::uint64)
+        set = nng_dialer_set_uint64;
+      else if constexpr (overload == opt_overload::string)
+        set = nng_dialer_set_string;
+      else if constexpr (overload == opt_overload::duration)
+        set = nng_dialer_set_ms;
+      else if constexpr (overload == opt_overload::sockaddr)
+        set = nng_dialer_set_addr;
+    }
+
+    return nngxx::invoke(set, obj, opt, val);
+  }
+};
+
+} // namespace nngxx

--- a/lib/include/nngxx/pipe.h
+++ b/lib/include/nngxx/pipe.h
@@ -29,61 +29,31 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 #pragma once
 
-#include "pars/init.h"
+#include "nngxx/iface/pipe.h"
 
-#include "nngxx/ctx.h"
-#include "nngxx/socket.h"
-
-#include <fmt/format.h>
-
-#include <typeinfo>
-#include <variant>
-
-namespace pars::net
+namespace nngxx
 {
 
-/**
- * @brief Represents an nng_socket or nng_ctx view
- */
-class tool_view
+using pipe_view = clev::iface<nng_pipe>;
+
+enum class pipe_ev
 {
-public:
-  /// Construct a tool_view from an nng_ctx view
-  explicit tool_view(nngxx::ctx_view c)
-    : tool_m{c}
-  {
-  }
-
-  /// Construct a tool_view from an nng_socket view
-  explicit tool_view(nngxx::socket_view s)
-    : tool_m{s}
-  {
-  }
-
-  /// Get the std::type_info of the underlying variant
-  const std::type_info& type() const
-  {
-    return std::visit([](auto& t) { return std::ref(typeid(t)); }, tool_m);
-  }
-
-  /// Get a string that represents the type of the underlying variant
-  const char* who() const { return tool_m.index() == 0 ? "Context" : "Socket"; }
-
-  /// The id of the underlying variant
-  int id() const
-  {
-    return std::visit([](const auto& t) { return t.id(); }, tool_m);
-  }
-
-  /// Formatter for debugging purpose
-  auto format_to(fmt::format_context& ctx) const -> decltype(ctx.out())
-  {
-    return fmt::format_to(ctx.out(), "{} #{}", who(), id());
-  }
-
-private:
-  /// The underlying variant that represents either an nng_socket or nng_ctx
-  const std::variant<nngxx::ctx_view, nngxx::socket_view> tool_m;
+  add_pre = NNG_PIPE_EV_ADD_PRE,
+  add_post = NNG_PIPE_EV_ADD_POST,
+  rem_post = NNG_PIPE_EV_REM_POST,
+  num = NNG_PIPE_EV_NUM
 };
 
-} // namespace pars::net
+inline nng_pipe_ev cast_pipe_ev(pipe_ev ev) noexcept
+{
+  return static_cast<nng_pipe_ev>(ev);
+}
+
+inline pipe_ev cast_pipe_ev(nng_pipe_ev ev) noexcept
+{
+  return static_cast<pipe_ev>(ev);
+}
+
+} // namespace nngxx
+
+static_assert(std::copyable<nngxx::pipe_view>);

--- a/lib/include/nngxx/socket_decl.h
+++ b/lib/include/nngxx/socket_decl.h
@@ -29,61 +29,19 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 #pragma once
 
-#include "pars/init.h"
+#include "clev/iface.h"
+#include "clev/own.h"
 
-#include "nngxx/ctx.h"
-#include "nngxx/socket.h"
+#include <nng/nng.h>
 
-#include <fmt/format.h>
+template<>
+struct clev::iface<nng_socket>;
 
-#include <typeinfo>
-#include <variant>
-
-namespace pars::net
+namespace nngxx
 {
 
-/**
- * @brief Represents an nng_socket or nng_ctx view
- */
-class tool_view
-{
-public:
-  /// Construct a tool_view from an nng_ctx view
-  explicit tool_view(nngxx::ctx_view c)
-    : tool_m{c}
-  {
-  }
+using socket_view = clev::iface<nng_socket>;
 
-  /// Construct a tool_view from an nng_socket view
-  explicit tool_view(nngxx::socket_view s)
-    : tool_m{s}
-  {
-  }
+using socket = clev::own<nng_socket>;
 
-  /// Get the std::type_info of the underlying variant
-  const std::type_info& type() const
-  {
-    return std::visit([](auto& t) { return std::ref(typeid(t)); }, tool_m);
-  }
-
-  /// Get a string that represents the type of the underlying variant
-  const char* who() const { return tool_m.index() == 0 ? "Context" : "Socket"; }
-
-  /// The id of the underlying variant
-  int id() const
-  {
-    return std::visit([](const auto& t) { return t.id(); }, tool_m);
-  }
-
-  /// Formatter for debugging purpose
-  auto format_to(fmt::format_context& ctx) const -> decltype(ctx.out())
-  {
-    return fmt::format_to(ctx.out(), "{} #{}", who(), id());
-  }
-
-private:
-  /// The underlying variant that represents either an nng_socket or nng_ctx
-  const std::variant<nngxx::ctx_view, nngxx::socket_view> tool_m;
-};
-
-} // namespace pars::net
+} // namespace nngxx

--- a/lib/include/pars/app/resources.h
+++ b/lib/include/pars/app/resources.h
@@ -116,13 +116,13 @@ public:
   {
     auto guard = std::lock_guard{mtx_m};
 
-    auto mtx = mtxs_m.emplace(std::piecewise_construct,
-                              std::forward_as_tuple(key), std::tuple());
+    auto mtx = mtxs_m.try_emplace(key);
+
     if (!mtx.second)
       throw std::runtime_error(fmt::format(
         "Unable to emplace a new Resource Mutex [key: 0x{:X}]", key));
 
-    auto res = resources_m.emplace(key, std::forward<args_t>(args)...);
+    auto res = resources_m.try_emplace(key, std::forward<args_t>(args)...);
 
     if (!res.second)
     {

--- a/lib/include/pars/comp/backend.h
+++ b/lib/include/pars/comp/backend.h
@@ -52,7 +52,7 @@ public:
 
   void init(const init_p& params)
   {
-    rep_m.sock().options(params.rep_opts);
+    rep_m.sock().set_options(params.rep_opts);
 
     rep_m.ctxs().start_recv(params.num_ctxs);
   }

--- a/lib/include/pars/comp/client.h
+++ b/lib/include/pars/comp/client.h
@@ -51,7 +51,7 @@ public:
     net::socket_opt req_opts;
   };
 
-  void init(const init_p& params) { req_m.sock().options(params.req_opts); }
+  void init(const init_p& params) { req_m.sock().set_options(params.req_opts); }
 
   struct connect_p
   {

--- a/lib/include/pars/concept/event.h
+++ b/lib/include/pars/concept/event.h
@@ -31,8 +31,6 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "pars/ev/kind_decl.h"
 
-#include <nngpp/msg.h>
-
 #include <concepts>
 #include <string_view>
 

--- a/lib/include/pars/ev/enqueuer.h
+++ b/lib/include/pars/ev/enqueuer.h
@@ -71,7 +71,7 @@ public:
     {
       if (dispatcher_m.terminating())
       {
-        p.close();
+        p.close().or_abort();
 
         return;
       }
@@ -95,7 +95,7 @@ public:
   }
 
   template<net::tool_c tool_t>
-  void queue_received(nng::msg m, int s_id, tool_t& t, net::pipe p)
+  void queue_received(nngxx::msg m, int s_id, tool_t& t, net::pipe p)
   {
     dispatcher_m.queue_back(received{std::move(m), {s_id, t, p}});
   }

--- a/lib/include/pars/ev/event.h
+++ b/lib/include/pars/ev/event.h
@@ -33,7 +33,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "pars/fmt/stl.h"
 #include "pars/net/dir.h"
 
-#include "nngxx/err.h"
+#include "clev/err.h"
 
 #include <cereal/types/vector.hpp>
 #include <fmt/base.h>

--- a/lib/include/pars/ev/event.h
+++ b/lib/include/pars/ev/event.h
@@ -33,11 +33,12 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "pars/fmt/stl.h"
 #include "pars/net/dir.h"
 
+#include "nngxx/err.h"
+
 #include <cereal/types/vector.hpp>
 #include <fmt/base.h>
 
 #include <chrono>
-#include <vector>
 
 namespace pars::ev
 {
@@ -116,9 +117,9 @@ struct exception
     {
       std::rethrow_exception(eptr);
     }
-    catch (nng::exception& e)
+    catch (clev::exception& e)
     {
-      return fmt::format("{} during {}", e.what(), e.who());
+      return fmt::format("{}", e.what());
     }
     catch (std::exception& e)
     {

--- a/lib/include/pars/ev/job.h
+++ b/lib/include/pars/ev/job.h
@@ -29,13 +29,12 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 #pragma once
 
+#include "nngxx/msg.h"
+
 #include "pars/ev/kind.h"
 #include "pars/ev/metadata.h"
 #include "pars/ev/serializer.h"
 #include "pars/ev/spec.h"
-
-#include <nngpp/msg.h>
-#include <nngpp/view.h>
 
 #include <any>
 #include <type_traits>
@@ -64,7 +63,7 @@ public:
 
   template<template<typename> typename kind_of, event_c event_t>
     requires(!is_same_kind_v<kind_of, received> ||
-             std::is_same_v<event_t, nng::msg>)
+             std::is_same_v<event_t, nngxx::msg>)
   kind_of<event_t> event()
   {
     return std::any_cast<kind_of<event_t>>(std::move(event_kind_m));
@@ -72,11 +71,11 @@ public:
 
   template<template<typename> typename kind_of, event_c event_t>
     requires(is_same_kind_v<kind_of, received> &&
-             !std::is_same_v<event_t, nng::msg>)
+             !std::is_same_v<event_t, nngxx::msg>)
   received<event_t> event()
   {
-    // get the received<nng::msg>
-    auto r = event<received, nng::msg>();
+    // get the received<nngxx::msg>
+    auto r = event<received, nngxx::msg>();
 
     auto& md = r.md();
 
@@ -110,7 +109,7 @@ template<template<typename> typename kind_of, event_c event_t>
   requires kind_c<kind_of>
 static std::size_t compute_spec_hash(const kind_of<event_t>& ke)
 {
-  if constexpr (std::is_same_v<kind_of<event_t>, received<nng::msg>>)
+  if constexpr (std::is_same_v<kind_of<event_t>, received<nngxx::msg>>)
     return ke.msg_hash();
   else
     return spec<kind_of<event_t>>::hash;

--- a/lib/include/pars/ev/kind.h
+++ b/lib/include/pars/ev/kind.h
@@ -67,9 +67,9 @@ template<typename event_t>
 received(event_t, metadata<received, event_t>) -> received<event_t>;
 
 template<>
-struct received<nng::msg> : base_kind<received, nng::msg>
+struct received<nngxx::msg> : base_kind<received, nngxx::msg>
 {
-  using event_type = nng::msg;
+  using event_type = nngxx::msg;
 
   using base_kind<received, event_type>::base_kind;
 

--- a/lib/include/pars/ev/klass.h
+++ b/lib/include/pars/ev/klass.h
@@ -29,10 +29,10 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 #pragma once
 
+#include "nngxx/msg.h"
+
 #include "pars/concept/kind.h"
 #include "pars/net/hash.h"
-
-#include <nngpp/msg.h>
 
 #include <string_view>
 
@@ -71,9 +71,9 @@ struct klass
 };
 
 template<>
-struct klass<nng::msg> : base_klass<nng::msg>
+struct klass<nngxx::msg> : base_klass<nngxx::msg>
 {
-  using event_type = nng::msg;
+  using event_type = nngxx::msg;
 
   static constexpr std::string_view uuid =
     "a7c09171-c503-4cb2-97e4-de8d3fe621b3";

--- a/lib/include/pars/ev/spec.h
+++ b/lib/include/pars/ev/spec.h
@@ -34,7 +34,6 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <cereal/cereal.hpp>
 #include <fmt/format.h>
-#include <nngpp/msg.h>
 
 namespace pars::ev
 {

--- a/lib/include/pars/fmt/nng.h
+++ b/lib/include/pars/fmt/nng.h
@@ -29,39 +29,19 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 #pragma once
 
+#include "nngxx/msg_header.h"
+#include "nngxx/pipe.h"
+
 #include "pars/net/hash.h"
 
+#include "pars/err.h"
+
 #include <fmt/format.h>
-#include <nngpp/error.h>
-#include <nngpp/msg.h>
-#include <nngpp/pipe_view.h>
-#include <nngpp/view.h>
 
 template<>
-struct fmt::formatter<nng::error> : formatter<std::string>
+struct fmt::formatter<nngxx::msg> : formatter<std::string>
 {
-  auto format(const nng::error& e, format_context& ctx) const
-    -> decltype(ctx.out())
-  {
-    return fmt::format_to(ctx.out(), "{}", nng::to_string(e));
-  }
-};
-
-template<>
-struct fmt::formatter<nng::exception> : formatter<std::string>
-{
-  auto format(const nng::exception& e, format_context& ctx) const
-    -> decltype(ctx.out())
-  {
-    return fmt::format_to(ctx.out(), "nng::exception during {} ({}) - {}]",
-                          e.who(), e.get_error(), e.what());
-  }
-};
-
-template<>
-struct fmt::formatter<nng::msg> : formatter<std::string>
-{
-  auto format(const nng::msg& m, format_context& ctx) const
+  auto format(const nngxx::msg& m, format_context& ctx) const
     -> decltype(ctx.out())
   {
     if (m.body().size() < sizeof(std::size_t))
@@ -84,20 +64,9 @@ struct fmt::formatter<nng::msg> : formatter<std::string>
 };
 
 template<>
-struct fmt::formatter<nng::view> : formatter<std::string>
+struct fmt::formatter<nngxx::pipe_view> : formatter<std::string>
 {
-  auto format(const nng::view& v, format_context& ctx) const
-    -> decltype(ctx.out())
-  {
-    return fmt::format_to(ctx.out(), "{}",
-                          std::string_view{v.data<char>(), v.size()});
-  }
-};
-
-template<>
-struct fmt::formatter<nng::pipe_view> : formatter<std::string>
-{
-  auto format(const nng::pipe_view& p, fmt::format_context& ctx) const
+  auto format(const nngxx::pipe_view& p, fmt::format_context& ctx) const
     -> decltype(ctx.out())
   {
     if (p)

--- a/lib/include/pars/net/context_opt.h
+++ b/lib/include/pars/net/context_opt.h
@@ -31,7 +31,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "pars/init.h"
 
-#include <nngpp/core.h>
+#include <nng/nng.h>
 
 #include <optional>
 

--- a/lib/include/pars/net/hash.h
+++ b/lib/include/pars/net/hash.h
@@ -29,10 +29,11 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 #pragma once
 
+#include "nngxx/msg_body.h"
+
 #include "pars/init.h"
 
 #include <fmt/format.h>
-#include <nngpp/msg.h>
 
 #include <cstddef>
 
@@ -45,12 +46,12 @@ static constexpr std::size_t hash_from_uuid(const std::string_view& uuid)
   constexpr std::uint64_t prime{0x100000001B3};
 
   if (uuid.size() != 36)
-    throw new std::runtime_error("Invalid UUID [size mismatch]");
+    throw std::runtime_error("Invalid UUID [size mismatch]");
 
   for (auto i : {8, 13, 18, 23})
   {
     if (uuid[i] != '-')
-      throw new std::runtime_error(
+      throw std::runtime_error(
         fmt::format("Invalid UUID [missing separator {}]", i));
   }
 
@@ -63,7 +64,7 @@ static constexpr std::size_t hash_from_uuid(const std::string_view& uuid)
 
     if (!(c >= '0' && c <= '9') && !(c >= 'A' && c <= 'F') &&
         !(c >= 'a' && c <= 'f'))
-      throw new std::runtime_error("Invalid UUID [non hex char found]");
+      throw std::runtime_error("Invalid UUID [non hex char found]");
 
     auto x = c - c >= 'a' ? ('a' - 10) : (c >= 'A' ? ('A' - 10) : '0');
 
@@ -73,7 +74,7 @@ static constexpr std::size_t hash_from_uuid(const std::string_view& uuid)
   return result;
 }
 
-static std::size_t hash_from_msg(const nng::msg& m)
+static std::size_t hash_from_msg(const nngxx::msg& m)
 {
   std::size_t h;
   if (m)

--- a/lib/include/pars/net/op.h
+++ b/lib/include/pars/net/op.h
@@ -29,30 +29,26 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 #pragma once
 
-#include "pars/err.h"
+#include "nngxx/aio.h"
+#include "nngxx/err.h"
+#include "nngxx/msg.h"
+#include "nngxx/pipe.h"
+
 #include "pars/ev/enqueuer.h"
 #include "pars/ev/event.h"
 #include "pars/ev/serializer.h"
 #include "pars/fmt/helpers.h"
 #include "pars/net/dir.h"
 
-#include <nngpp/aio.h>
-#include <nngpp/ctx_view.h>
-#include <nngpp/pipe_view.h>
-#include <nngpp/socket_view.h>
 #include <spdlog/spdlog.h>
 
+#include <expected>
 #include <functional>
-
-namespace nng
-{
-
-using cb_f = std::function<void(nng::error, nng::msg)>;
-
-} // namespace nng
 
 namespace pars::net
 {
+
+using cb_f = std::function<void(clev::expected<void>, nngxx::msg)>;
 
 class op
 {
@@ -66,21 +62,22 @@ public:
   explicit operator bool() { return static_cast<bool>(aio_m); }
 
   template<ev::event_c event_t, tool_c tool_t>
-  void send(ev::enqueuer& r, tool_t& t, pipe p, event_t ev)
+  clev::expected<void> send(ev::enqueuer& r, tool_t& t, pipe p, event_t ev)
   {
-    nng::msg m = ev::serialize::to_network(ev);
+    auto m = ev::serialize::to_network(ev);
 
     if (p)
       m.set_pipe(p);
 
     pars::debug(SL, lf::net, "{}: Send Message [{}]!", f::pntl{p, t}, m);
 
-    // replace the operation with the new one
-    cb_m = [&, p, ev = std::move(ev)](nng::error ec, nng::msg m) mutable {
-      if (ec == nng::error::success)
+    // replace the callback with the new one
+    cb_m = [&, p, ev = std::move(ev)](clev::expected<void> res,
+                                      nngxx::msg m) mutable {
+      if (res)
       {
         // NOTE: m is empty on success
-        
+
         pars::debug(SL, lf::net, "{}: Sent Event [{}]!", f::pntl{p, t}, ev);
 
         r.queue_sent(std::move(ev), t.socket_id(), t, p);
@@ -92,18 +89,20 @@ public:
         auto pv = m.get_pipe();
 
         pars::err(SL, lf::net, "{}: Error Sending {}! [msg:{},err:{}]",
-                  f::pntl{pv, t}, nametype(ev), m, ec);
+                  f::pntl{pv, t}, nametype(ev), m, res.error());
 
-        r.queue_fire(ev::network_error{ec, dir::out}, t.socket_id(), t, pv);
+        r.queue_fire(ev::network_error{res.error(), dir::out}, t.socket_id(), t,
+                     pv);
       }
     };
 
-    // make aio - NOTE: pass this, cant move op
-    aio_m = nng::make_aio(op::send_cb, this);
+    return nngxx::make_aio(op::send_cb, this, std::move(m))
+      .and_assign_to(aio_m)
+      .and_then([&](auto aio) {
+        t.send_aio(aio);
 
-    // start send
-    aio_m.set_msg(std::move(m));
-    t.send_aio(aio_m);
+        return clev::expected<void>{};
+      });
   }
 
   template<tool_c tool_t>
@@ -112,8 +111,8 @@ public:
     pars::debug(SL, lf::net, "{}: Receive Message!", f::pntl{{}, t});
 
     // replace the operation with the new one
-    cb_m = [&](nng::error ec, nng::msg m) {
-      if (ec == nng::error::success)
+    cb_m = [&](clev::expected<void> res, nngxx::msg m) {
+      if (res)
       {
         // NOTE: m is not empty on success
 
@@ -128,16 +127,18 @@ public:
       {
         // NOTE: m is empty on failure
 
-        auto pv = nng::pipe_view();
+        auto pv = nngxx::pipe_view();
 
-        pars::err(SL, lf::net, "{}: Error Receiving! [{}]", f::pntl{pv, t}, ec);
+        pars::err(SL, lf::net, "{}: Error Receiving! [{}]", f::pntl{pv, t},
+                  res.error());
 
-        r.queue_fire(ev::network_error{ec, dir::in}, t.socket_id(), t, pv);
+        r.queue_fire(ev::network_error{res.error(), dir::in}, t.socket_id(), t,
+                     pv);
       }
     };
 
     // make aio - NOTE: pass this, cant move op
-    aio_m = nng::make_aio(op::recv_cb, this);
+    aio_m = nngxx::make_aio(op::send_cb, this).value_or_abort();
 
     // start recv
     t.recv_aio(aio_m);
@@ -145,8 +146,8 @@ public:
 
   void sleep(nng_duration ms, std::function<void()> f)
   {
-    cb_m = [&, f](nng::error e, nng::msg m) {
-      if (e == nng::error::success)
+    cb_m = [&, f](clev::expected<void> res, nngxx::msg m) {
+      if (res)
       {
         // the sleep completed successfully, execute f
         f();
@@ -154,9 +155,9 @@ public:
     };
 
     // make aio - NOTE: pass this, cant move op
-    aio_m = nng::make_aio(op::sleep_cb, this);
+    aio_m = nngxx::make_aio(op::send_cb, this).value_or_abort();
 
-    nng::sleep(ms, aio_m);
+    nngxx::sleep(ms, aio_m);
   }
 
   void reset_sleep(nng_duration ms)
@@ -164,9 +165,9 @@ public:
     stop();
 
     // make aio - NOTE: pass this, cant move op
-    aio_m = nng::make_aio(op::sleep_cb, this);
+    aio_m = nngxx::make_aio(op::send_cb, this).value_or_abort();
 
-    nng::sleep(ms, aio_m);
+    nngxx::sleep(ms, aio_m);
   }
 
   /**
@@ -177,7 +178,10 @@ public:
    * the handle aio. If the operation was successful, then 0 is returned.
    * Otherwise a non-zero error code is returned.
    */
-  nng::error result() const { return aio_m.result(); }
+  std::error_code result() const
+  {
+    return aio_m.result().error_or(nngxx::err::success);
+  }
 
   /**
    * @brief abort asynchronous I/O operation
@@ -189,7 +193,7 @@ public:
    * If the operation is aborted, then the callback for the handle will be
    * called, and the function result() will return the error err.
    */
-  void abort(nng::error err) const { aio_m.abort(static_cast<int>(err)); }
+  void abort(nngxx::err err) { aio_m.abort(err); }
 
   /**
    * @brief cancel asynchronous I/O operation
@@ -206,9 +210,9 @@ public:
    * finished, or no operation has been started yet), then this function has no
    * effect.
    *
-   * Same as abort(nng::error::canceled)
+   * Same as abort(nngxx::error::canceled)
    */
-  void cancel() const { aio_m.cancel(); }
+  void cancel() { aio_m.cancel(); }
 
   /**
    * @brief wait for asynchronous I/O operation
@@ -239,16 +243,16 @@ private:
     // get the result
     auto res = self->aio_m.result();
 
-    nng::msg msg;
+    nngxx::msg msg;
 
-    if (res != nng::error::success)
+    if (res)
     {
       // take ownership of the message
       msg = self->aio_m.release_msg();
     }
 
     // execute the callback passing ownership of the message
-    self->cb_m(res, std::move((msg)));
+    self->cb_m(res, std::move(msg));
   }
 
   static void recv_cb(void* arg)
@@ -258,40 +262,29 @@ private:
     // get the result
     auto res = self->aio_m.result();
 
-    nng::msg msg;
+    nngxx::msg msg;
 
-    if (res == nng::error::success)
+    if (res)
     {
       // take ownership of the message
       msg = self->aio_m.release_msg();
     }
 
     // execute the callback passing ownership of the message
-
-    /*
-    we're going to pass here a view of the msg so that the receiving handler
-    will be able to serialize it into an event.
-    */
-
-    self->cb_m(res, std::move((msg)));
-
-    /*
-    now that the msg was used, we can get rid of it
-    */
+    self->cb_m(res, std::move(msg));
   }
 
   static void sleep_cb(void* arg)
   {
     auto self = static_cast<op*>(arg);
 
-    auto res = self->aio_m.result();
+    auto ok = self->aio_m.result();
 
-    if (res == nng::error::success)
-      self->cb_m(res, nng::msg{});
+    self->cb_m(ok, nngxx::msg{});
   }
 
-  nng::aio aio_m;
-  nng::cb_f cb_m;
+  nngxx::aio aio_m;
+  cb_f cb_m;
 };
 
 } // namespace pars::net

--- a/lib/include/pars/net/pipe.h
+++ b/lib/include/pars/net/pipe.h
@@ -29,16 +29,17 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 #pragma once
 
+#include "nngxx/pipe.h"
+#include "nngxx/socket.h"
+
 #include "pars/fmt/nng.h"
 
 #include <fmt/format.h>
-#include <nngpp/pipe_view.h>
-#include <nngpp/socket_view.h>
 
 namespace pars::net
 {
 
-class pipe : public nng::pipe_view
+class pipe : public nngxx::pipe_view
 {
 public:
   pipe()
@@ -47,8 +48,8 @@ public:
   {
   }
 
-  pipe(nng::pipe_view pv) noexcept
-    : nng::pipe_view{pv.get()}
+  pipe(nngxx::pipe_view& pv) noexcept
+    : nngxx::pipe_view{pv}
     , id_m{pv.id()}
     , socket_id_m{pv.get_socket().id()}
   {
@@ -58,13 +59,12 @@ public:
 
   int socket_id() const { return socket_id_m; }
 
-  operator bool() { return nng::pipe_view::operator bool(); }
-
-  void close() const noexcept { nng_pipe_close(p); }
+  operator bool() { return nngxx::pipe_view::operator bool(); }
 
   auto format_to(fmt::format_context& ctx) const -> decltype(ctx.out())
   {
-    return fmt::format_to(ctx.out(), "{}", static_cast<nng::pipe_view>(*this));
+    return fmt::format_to(ctx.out(), "{}",
+                          static_cast<nngxx::pipe_view>(*this));
   }
 
 private:

--- a/lib/include/pars/net/pull.h
+++ b/lib/include/pars/net/pull.h
@@ -34,8 +34,6 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "pars/ev/make_hf.h"
 #include "pars/net/socket.h"
 
-#include <nngpp/protocol/pull0.h>
-
 namespace pars::net
 {
 
@@ -47,7 +45,7 @@ class pull
 public:
   /// Construct a pull
   pull(ev::hf_registry& h, ev::enqueuer& r)
-    : sock_m{r, nng::pull::v0::open()}
+    : sock_m{r, nngxx::pull::v0::make_socket().value_or_abort()}
     , hf_registry_m{h}
   {
   }

--- a/lib/include/pars/net/push.h
+++ b/lib/include/pars/net/push.h
@@ -33,8 +33,6 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "pars/ev/hf_registry__insert.h"
 #include "pars/net/socket.h"
 
-#include <nngpp/protocol/push0.h>
-
 namespace pars::net
 {
 
@@ -46,7 +44,7 @@ class push
 public:
   /// Construct a push
   push(ev::hf_registry& h, ev::enqueuer& r)
-    : sock_m{r, nng::push::v0::open()}
+    : sock_m{r, nngxx::push::v0::make_socket().value_or_abort()}
     , hf_registry_m{h}
   {
   }

--- a/lib/include/pars/net/rep.h
+++ b/lib/include/pars/net/rep.h
@@ -35,8 +35,6 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "pars/net/context_registry.h"
 #include "pars/net/socket.h"
 
-#include <nngpp/protocol/rep0.h>
-
 namespace pars::net
 {
 
@@ -48,7 +46,7 @@ class rep
 public:
   /// Construct a rep
   rep(ev::hf_registry& h, ev::enqueuer& r)
-    : sock_m{r, nng::rep::v0::open()}
+    : sock_m{r, nngxx::rep::v0::make_socket().value_or_abort()}
     , ctx_registry_m{r, sock_m}
     , hf_registry_m{h}
   {

--- a/lib/include/pars/net/req.h
+++ b/lib/include/pars/net/req.h
@@ -35,8 +35,6 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "pars/net/context_registry.h"
 #include "pars/net/socket.h"
 
-#include <nngpp/protocol/req0.h>
-
 namespace pars::net
 {
 
@@ -48,7 +46,7 @@ class req
 public:
   /// Construct a req
   req(ev::hf_registry& h, ev::enqueuer& r)
-    : sock_m{r, nng::req::v0::open()}
+    : sock_m{r, nngxx::req::v0::make_socket().value_or_abort()}
     , ctx_registry_m{r, sock_m}
     , hf_registry_m{h}
   {

--- a/test/events-network.cpp
+++ b/test/events-network.cpp
@@ -37,7 +37,7 @@ namespace pars::tests
 {
 
 using NetworkEvents =
-  ::testing::Types<nng::msg, ev::network_error, ev::creating_pipe,
+  ::testing::Types<nngxx::msg, ev::network_error, ev::creating_pipe,
                    ev::pipe_created, ev::pipe_removed>;
 
 template<typename event_t>
@@ -73,11 +73,12 @@ TYPED_TEST(NetworkKinds, EventsCanBeFired)
   if (std::default_initializable<event_type>)
   {
     // we can instantiate event_type{} without specifing the type event_type
-    ev::fired{event_type{}, {1, net::tool_view{nng::ctx_view{}}, net::pipe{}}};
+    ev::fired{event_type{},
+              {1, net::tool_view{nngxx::ctx_view{}}, net::pipe{}}};
 
     // we can instantiate specifing the type event_type
     ev::fired<event_type>{{},
-                          {1, net::tool_view{nng::ctx_view{}}, net::pipe{}}};
+                          {1, net::tool_view{nngxx::ctx_view{}}, net::pipe{}}};
   }
 }
 
@@ -92,10 +93,11 @@ TYPED_TEST(NetworkKinds, EventsCanBeSent)
   if (std::default_initializable<event_type>)
   {
     // we can instantiate event_type{} without specifing the type event_type
-    ev::sent{event_type{}, {1, net::tool_view{nng::ctx_view{}}, net::pipe{}}};
+    ev::sent{event_type{}, {1, net::tool_view{nngxx::ctx_view{}}, net::pipe{}}};
 
     // we can instantiate specifing the type event_type
-    ev::sent<event_type>{{}, {1, net::tool_view{nng::ctx_view{}}, net::pipe{}}};
+    ev::sent<event_type>{{},
+                         {1, net::tool_view{nngxx::ctx_view{}}, net::pipe{}}};
   }
 }
 
@@ -112,11 +114,11 @@ TYPED_TEST(NetworkKinds, EventsCanBeReceived)
   {
     // we can instantiate event_type{} without specifing the type event_type
     ev::received{event_type{},
-                 {1, net::tool_view{nng::ctx_view{}}, net::pipe{}}};
+                 {1, net::tool_view{nngxx::ctx_view{}}, net::pipe{}}};
 
     // we can instantiate specifing the type event_type
-    ev::received<event_type>{{},
-                             {1, net::tool_view{nng::ctx_view{}}, net::pipe{}}};
+    ev::received<event_type>{
+      {}, {1, net::tool_view{nngxx::ctx_view{}}, net::pipe{}}};
   }
 }
 

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -5,7 +5,6 @@
     "fmt",
     "gtest",
     "nng",
-    "nngpp",
     "spdlog"
   ]
 }


### PR DESCRIPTION
This contains an experimental API to bind C libraries to C++23 and allows applications that wants to to opt out from using exceptions and rely to an experimental clev::expected based on std::expected.